### PR TITLE
test/742/bottomButtons

### DIFF
--- a/app/src/main/java/test/pages/BottomBarPage.java
+++ b/app/src/main/java/test/pages/BottomBarPage.java
@@ -1,0 +1,43 @@
+package test.pages;
+
+import io.appium.java_client.AppiumBy;
+import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class BottomBarPage {
+
+    private final AppiumDriver driver;
+    private final List<String> expectedLabels =
+            Arrays.asList("RESTART", "PASS DAY", "BUY FOOD", "SHOW TUTORIAL");
+
+    public BottomBarPage(AppiumDriver driver) {
+        this.driver = driver;
+    }
+
+    /**
+     * Verifica que cada texto esperado tenga al menos un botón,
+     * que esté visible y su texto coincida exactamente.
+     */
+    public void verifyAllButtons() {
+        for (String label : expectedLabels) {
+            List<WebElement> elems = driver.findElements(
+                    AppiumBy.androidUIAutomator("new UiSelector().text(\"" + label + "\")")
+            );
+            if (elems.isEmpty()) {
+                throw new AssertionError("Botón no encontrado: " + label);
+            }
+            WebElement btn = elems.get(0);
+            if (!btn.isDisplayed()) {
+                throw new AssertionError("Botón no visible: " + label);
+            }
+            if (!btn.getText().equals(label)) {
+                throw new AssertionError(
+                        String.format("Texto esperado '%s' pero se encontró '%s'", label, btn.getText())
+                );
+            }
+        }
+    }
+}

--- a/app/src/main/java/test/session/Session.java
+++ b/app/src/main/java/test/session/Session.java
@@ -1,29 +1,59 @@
 package test.session;
 
+import android.os.Build;
 
 import io.appium.java_client.AppiumDriver;
-import test.factoryDevices.FactoryDevices;
+import io.appium.java_client.android.AndroidDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
 
 public class Session {
-    private static Session session = null;
-    private AppiumDriver device;
-    private Session(){
-        // todo
-        device = FactoryDevices.make("android").create();
+    private static Session instance = null;
+    // Renombramos 'device' a 'driver'
+    private final AppiumDriver driver;
+
+    private Session() {
+        DesiredCapabilities caps = new DesiredCapabilities();
+        caps.setCapability("platformName",       "Android");
+        caps.setCapability("appium:deviceName",  "Pixel 9 Pro XL");
+        caps.setCapability("appium:platformVersion", "16");
+        caps.setCapability("appium:automationName",   "UiAutomator2");
+        caps.setCapability("appium:appPackage",       "edu.upb.lp.genericgame");
+        caps.setCapability("appium:appActivity",      "edu.upb.lp.core.activities.AndroidGameActivity");
+        caps.setCapability("appium:noReset",          true);
+
+        try {
+            // Aquí usas el mismo campo 'driver'
+            driver = new AndroidDriver(
+                    new URL("http://127.0.0.1:4723/"),
+                    caps
+            );
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("URL de Appium malformada", e);
+        }
     }
 
-    public static Session getInstance(){
-        if (session == null)
-            session = new Session();
-        return session;
+    public static Session getInstance() {
+        if (instance == null) {
+            instance = new Session();
+        }
+        return instance;
     }
 
-    public void closeApp(){
-        device.quit();
-        session = null;
+    public AppiumDriver getDevice() {
+        return driver;
     }
 
-    public AppiumDriver getDevice(){
-        return  device;
+    public static void reset() {
+        if (instance != null) {
+            instance.driver.quit();
+            instance = null;
+        }
     }
 }

--- a/app/src/test/java/testSuite/BottomBarTest.java
+++ b/app/src/test/java/testSuite/BottomBarTest.java
@@ -1,0 +1,32 @@
+package testSuite;
+
+import io.appium.java_client.AppiumDriver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test.pages.BottomBarPage;
+import test.session.Session;
+
+public class BottomBarTest {
+
+    private AppiumDriver driver;
+    private BottomBarPage bottomBar;
+
+    @Before
+    public void setUp() {
+        Session.reset();
+        driver    = Session.getInstance().getDevice();
+        bottomBar = new BottomBarPage(driver);
+    }
+
+    @After
+    public void tearDown() {
+        driver.quit();
+        Session.reset();
+    }
+
+    @Test
+    public void allButtonsArePresentAndCorrect() {
+        bottomBar.verifyAllButtons();
+    }
+}


### PR DESCRIPTION
Se implementó una prueba automatizada con Appium que verifica que al iniciar la aplicación, los cuatro botones inferiores estén presentes, sean visibles y tengan el texto correcto: "RESTART", "PASS DAY", "BUY FOOD" y "SHOW TUTORIAL".
El test falló: 
![test_742](https://github.com/user-attachments/assets/2e1d8f31-17d3-4cc1-8b56-247d5ceac99a)
