### PR TITLE
Test: #750 Verificar la posición inicial del jugador

### DIFF
--- a/app/src/main/java/edu/upb/lp/test/activities/MainActivity.java
+++ b/app/src/main/java/edu/upb/lp/test/activities/MainActivity.java
@@ -1,9 +1,12 @@
 package edu.upb.lp.test.activities;
 
 import io.appium.java_client.AppiumDriver;
+import test.controls.Button;
 
 import org.openqa.selenium.By;
-
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 public class MainActivity {
 
     private final AppiumDriver driver;
@@ -32,4 +35,12 @@ public class MainActivity {
     public void clickButtonBuyFood() {
         driver.findElement(By.xpath("//android.widget.Button[@text=\"BUY FOOD\"]")).click();
     }
+    public class Position {
+        public Button leftBug;
+        public Button rightBug;
+        public Position() {
+            this.leftBug = new Button(By.xpath("//android.widget.TableLayout[@resource-id=\"edu.upb.lp.genericgame:id/maingrid\"]/android.widget.TableRow[5]/android.widget.TextView[4]"));
+            this.rightBug = new Button(By.xpath("//android.widget.TableLayout[@resource-id=\"edu.upb.lp.genericgame:id/maingrid\"]/android.widget.TableRow[5]/android.widget.TextView[5]"));
 }
+    }
+        }

--- a/app/src/main/java/test/session/Session.java
+++ b/app/src/main/java/test/session/Session.java
@@ -13,13 +13,12 @@ public class Session {
     private AppiumDriver device;
     private Session(){
         DesiredCapabilities caps = new DesiredCapabilities();
-        caps.setCapability("appium:deviceName", "Galaxy A34 5G");
-        caps.setCapability("appium:platformVersion", "13");
         caps.setCapability("platformName", "Android");
+        caps.setCapability("appium:deviceName", "sdk_gphone64_x86_64");
+        caps.setCapability("appium:platformVersion", "16");
         caps.setCapability("appium:automationName", "uiautomator2");
         caps.setCapability("appium:appPackage", "edu.upb.lp.genericgame");
         caps.setCapability("appium:appActivity", "edu.upb.lp.core.activities.AndroidGameActivity");
-
         try {
             device = new AppiumDriver(new URL("http://127.0.0.1:4723/"), caps);
         } catch (MalformedURLException e) {

--- a/app/src/test/java/testSuite/InitialPositionTest.java
+++ b/app/src/test/java/testSuite/InitialPositionTest.java
@@ -1,0 +1,49 @@
+package testSuite;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import edu.upb.lp.test.activities.MainActivity;
+import io.appium.java_client.AppiumDriver;
+import test.session.Session;
+import org.junit.Assert;
+import org.openqa.selenium.By;
+
+
+public class InitialPositionTest {
+
+    private AppiumDriver driver;
+    private MainActivity.Position position;
+
+    // Posiciones que vamos a verificar
+    private final By originalPosition = By.xpath("//android.widget.TableLayout[@resource-id=\"edu.upb.lp.genericgame:id/maingrid\"]/android.widget.TableRow[5]/android.widget.TextView[4]"); // leftBug
+    private final By newPosition = By.xpath("//android.widget.TableLayout[@resource-id=\"edu.upb.lp.genericgame:id/maingrid\"]/android.widget.TableRow[4]/android.widget.TextView[4]");
+
+    private MainActivity mainActivity;
+
+    @Before
+    public void setUp() {
+        Session.resetInstance();
+        driver = Session.getInstance().getDevice();
+        mainActivity = new MainActivity(driver);
+    }
+    @Test
+    public void testBugInitialPosition() {
+        String actualText = driver.findElement(originalPosition).getText();
+
+        String expectedBugText = "";
+
+        System.out.println("Texto en la posición inicial: " + actualText);
+
+        Assert.assertEquals("El bug no está en la posición inicial esperada.", expectedBugText,actualText);
+    }
+    @After
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
En la aplicación de Android se tenía que verificar que el "bichito" comience en una posición inicial correcta al entrar a la aplicación, todo esto con un test automatizado  